### PR TITLE
Fixed code examples, changed ZZArchive to ZZMutableArchive

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ Reading an existing zip file:
 	
 Writing a new zip file:
 
-	ZZMutableArchive* newArchive = [ZZArchive archiveWithContentsOfURL:[NSURL fileURLWithPath:@"/tmp/new.zip"]];
+	ZZMutableArchive* newArchive = [ZZMutableArchive archiveWithContentsOfURL:[NSURL fileURLWithPath:@"/tmp/new.zip"]];
 	newArchive.entries =
 	@[
 		[ZZArchiveEntry archiveEntryWithFileName:@"first.text"
@@ -52,7 +52,7 @@ Writing a new zip file:
 	
 Updating an existing zip file:
 
-	ZZMutableArchive* oldArchive = [ZZArchive archiveWithContentsOfURL:[NSURL fileURLWithPath:@"/tmp/old.zip"]];
+	ZZMutableArchive* oldArchive = [ZZMutableArchive archiveWithContentsOfURL:[NSURL fileURLWithPath:@"/tmp/old.zip"]];
 	oldArchive.entries = [oldArchive.entries arrayByAddingObject:
 		[ZZArchiveEntry archiveEntryWithFileName:@"second.text"
 										compress:YES


### PR DESCRIPTION
The code examples in current form would throw an error: 
`-[ZZArchive setEntries:]: unrecognized selector sent to instance 0x101913540`

Due to initializing with non-mutable ZZArchive. Changing to examples to use ZZMutableArchive might save someone some frustration ;).
