### PR TITLE
Update podspec to support OS X

### DIFF
--- a/zipzap.podspec
+++ b/zipzap.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "zipzap"
-  s.version      = "4.0"
+  s.version      = "5.1"
   s.summary      = "zipzap is a zip file I/O library for Mac OS X and iOS."
   s.description  = <<-DESC
 The zip file is an ideal container for compound Objective-C documents. Zip files are widely used and well understood. You can randomly access their parts. The format compresses decently and has extensive operating system and tool support. So we want to make this format an even easier choice for you. Thus, the library features:
@@ -12,14 +12,16 @@ The zip file is an ideal container for compound Objective-C documents. Zip files
   s.homepage     = 'https://github.com/pixelglow/zipzap'
 
   s.author       = 'Pixelglow Software'
-  s.source       = { :git => 'https://github.com/pixelglow/zipzap.git', :tag => '4.0' }
+  s.source       = { :git => 'https://github.com/pixelglow/zipzap.git', :tag => '5.1' }
   s.license      = 'BSD'
 
-  s.platform     = :ios, '5.1'
-  s.source_files = 'Classes', 'zipzap/**/*.{h,m,mm}'
-  s.public_header_files = 'zipzap/**/*.h'
-  s.frameworks   = 'Foundation'
-  s.libraries    = 'c++', 'z'
-  s.requires_arc = true
-  s.xcconfig     = { 'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++' }
+  s.osx.deployment_target = '10.7'
+  s.ios.deployment_target = '5.1'
+  s.source_files          = 'zipzap/**/*.{h,m,mm}'
+  s.public_header_files   = 'zipzap/**/*.h'
+  s.osx.frameworks        = 'Foundation', 'ApplicationServices'
+  s.ios.frameworks        = 'Foundation'
+  s.libraries             = 'c++', 'z'
+  s.requires_arc          = true
+  s.xcconfig              = { 'OTHER_CPLUSPLUSFLAGS' => '-std=gnu++11 -stdlib=libc++' }
 end


### PR DESCRIPTION
- Specify the deployment target for OS X.
- Add an OS X-specific framework.
- Bump library version (required to publish new podspec; please run `git tag 5.1` after merge.)
