### PR TITLE
support for OSX when using cocoapods

### DIFF
--- a/zipzap.podspec
+++ b/zipzap.podspec
@@ -15,7 +15,9 @@ The zip file is an ideal container for compound Objective-C documents. Zip files
   s.source       = { :git => 'https://github.com/pixelglow/zipzap.git', :tag => '4.0' }
   s.license      = 'BSD'
 
-  s.platform     = :ios, '5.1'
+  s.ios.deployment_target = "5.1"
+  s.osx.deployment_target = "10.7"
+  
   s.source_files = 'Classes', 'zipzap/**/*.{h,m,mm}'
   s.public_header_files = 'zipzap/**/*.h'
   s.frameworks   = 'Foundation'


### PR DESCRIPTION
adds support of deployment targets iOS5 and OSX 10.7

linting says:
rick$ pod spec lint --local zipzap.podspec

 -> zipzap (4.0)

Analyzed 1 podspec.

zipzap.podspec passed validation.
