### PR TITLE
build for more than just the active architecture

### DIFF
--- a/zipzap.xcodeproj/project.pbxproj
+++ b/zipzap.xcodeproj/project.pbxproj
@@ -550,7 +550,6 @@
 		D899CF7C162C5E8400112F49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -594,7 +593,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = zipzap;
 				SDKROOT = macosx;
 			};
@@ -672,7 +670,6 @@
 				HEADER_SEARCH_PATHS = ../zipzap;
 				INFOPLIST_FILE = "zipzapTests/zipzapTests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = zipzapTests;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = xctest;


### PR DESCRIPTION
This covers cases where you're compiling with a library which only supports one architecture and you're compiling for a more recent architecture.

In my example, Unity only supports armv7, but the iPad I'm deploying to is armv7s, so zipzap doesn't compile for armv7.

This commit fixes issues in cases such as the above.
