### PR TITLE
Update zipzap.podspec

### DIFF
--- a/zipzap.podspec
+++ b/zipzap.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "zipzap"
-  s.version      = "6.0"
+  s.version      = "7.0"
   s.summary      = "zipzap is a zip file I/O library for Mac OS X and iOS."
   s.description  = <<-DESC
 The zip file is an ideal container for compound Objective-C documents. Zip files are widely used and well understood. You can randomly access their parts. The format compresses decently and has extensive operating system and tool support. So we want to make this format an even easier choice for you. Thus, the library features:


### PR DESCRIPTION
Update podspec version from 6.0 to 6.1.
Release version (tags) are mapped to a certain commit.
6.0 is mapped to 7fe656be30e550b97258579a6763a09c59bfd660

Cocoapods clones that commit in stead of c27f9e101eb545b464c16595fbac7c326203cc41 - the one that has the latest podspec and the AES encryption support.

Updating the podspec version to 6.1 and creating a new release (6.1) would allow CocoaPods to clone the correct version.
