### PR TITLE
Fix memory corruption when reading uncompressed archives on pre-10.9 systems.

### DIFF
--- a/zipzap/ZZOldArchiveEntry.mm
+++ b/zipzap/ZZOldArchiveEntry.mm
@@ -344,8 +344,8 @@
 		switch (self.compressionMethod)
 		{
 			case ZZCompressionMethod::stored:
-				// unencrypted, stored: just return as-is
-				return [fileData copy];
+				// unencrypted, stored: just return as-is. Make sure to create a new object since [NSData copy] returns the same object on pre-10.9 systems.
+				return [[NSData alloc] initWithBytes:fileData.bytes length:fileData.length];
 			case ZZCompressionMethod::deflated:
 				// unencrypted, deflated: inflate in one go
 				return [ZZInflateInputStream decompressData:fileData
@@ -392,8 +392,8 @@
 	NSData* fileData = [self fileData];
 	
 	if (self.compressionMethod == ZZCompressionMethod::stored && _encryptionMode == ZZEncryptionModeNone)
-		// simple data provider that just wraps the data
-		return CGDataProviderCreateWithCFData((__bridge CFDataRef)[fileData copy]);
+		// simple data provider that just wraps the data.  Make sure to create a new object since [NSData copy] returns the same object on pre-10.9 systems.
+		return CGDataProviderCreateWithCFData((__bridge CFDataRef)[[NSData alloc] initWithBytes:fileData.bytes length:fileData.length]);
 	else
 		return ZZDataProvider::create(^
 									  {


### PR DESCRIPTION
When reading a file from an archive which is stored unencrypted and without compression, data are simply copied in the `-newData*` methods. However, on pre-OS X 10.9 systems, `[NSData copy]` simply returns the same object (this bug is also documented in [rdar://14670403](http://openradar.appspot.com/14670403)). On OS X 10.9, `-copy` returns a new object. This issue led to a memory corruption when reading the unarchived data from zip files later on.
The pull request fixes this problem by using `[[NSData alloc] initWithBytes:length:]`, which always copies the passed data.
