### PR TITLE
Fixed an issue "Writing a new zip file" example doesn't work.

### DIFF
--- a/zipzap/ZZArchive.mm
+++ b/zipzap/ZZArchive.mm
@@ -42,7 +42,7 @@ static const size_t ENDOFCENTRALDIRECTORY_MINSEARCH = sizeof(ZZEndOfCentralDirec
 						 error:(out NSError**)error
 {
 	return [[self alloc] initWithChannel:[[ZZFileChannel alloc] initWithURL:URL]
-								 options:nil
+								 options:@{ ZZOpenOptionsCreateIfMissingKey: @YES }
 								   error:error];
 }
 


### PR DESCRIPTION
Fixed an issue "Writing a new zip file" example doesn't work.
Without ZZOpenOptionsCreateIfMissingKey option in archiveWithURL:error: new zip file is never created.
