### PR TITLE
Fixed the podspec in order to stop disabling exceptions project-wide (#78).

### DIFF
--- a/zipzap.podspec.json
+++ b/zipzap.podspec.json
@@ -24,12 +24,18 @@
   "libraries": [
     "z"
   ],
-  "xcconfig": {
-    "CLANG_CXX_LANGUAGE_STANDARD": "c++11",
-    "CLANG_CXX_LIBRARY": "libc++"
-  },
-  "compiler_flags": "-fno-objc-exceptions -fno-exceptions",
-  "source_files": "zipzap/*.{h,m,mm,cpp}",
+  "subspecs": [
+    {
+      "name": "objc",
+      "compiler_flags": "-fno-objc-exceptions",
+      "source_files": "zipzap/*.{h,m}"
+    },
+    {
+      "name": "objc++",
+      "compiler_flags": "-fno-objc-exceptions -fno-exceptions -std=c++11 -stdlib=libc++",
+      "source_files": "zipzap/*.{mm,cpp}"
+    }
+  ],
   "public_header_files": ["zipzap/zipzap.h", "zipzap/ZZArchive.h", "zipzap/ZZArchiveEntry.h", "zipzap/ZZConstants.h", "zipzap/ZZError.h"],
   "ios": {
     "frameworks": [


### PR DESCRIPTION
Moved the offending build settings from "xcconfig" to equivalents in "compiler_flags" so that they affect the zipzap source files only, and don't contaminate the rest of the host project.
