### PR TITLE
Update for Xcode 6.3

### DIFF
--- a/zipzap.xcodeproj/project.pbxproj
+++ b/zipzap.xcodeproj/project.pbxproj
@@ -516,7 +516,7 @@
 		D899CF77162C5E8400112F49 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0630;
 			};
 			buildConfigurationList = D899CF7A162C5E8400112F49 /* Build configuration list for PBXProject "zipzap" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -670,6 +670,7 @@
 		D899CF7C162C5E8400112F49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};

--- a/zipzap.xcodeproj/xcshareddata/xcschemes/zipzap (OS X).xcscheme
+++ b/zipzap.xcodeproj/xcshareddata/xcschemes/zipzap (OS X).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/zipzap.xcodeproj/xcshareddata/xcschemes/zipzap (iOS).xcscheme
+++ b/zipzap.xcodeproj/xcshareddata/xcschemes/zipzap (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Xcode 6.3 shows a warning requesting to upgrade project settings. This patch does it.