### PR TITLE
Fix missing streamError

### DIFF
--- a/ZipZap/ZZAESDecryptInputStream.mm
+++ b/ZipZap/ZZAESDecryptInputStream.mm
@@ -95,6 +95,11 @@ static const uint WINZIP_PBKDF2_ROUNDS = 1000;
 	return _status;
 }
 
+- (NSError*)streamError
+{
+	return nil;
+}
+
 - (void)open
 {
 	[_upstream open];


### PR DESCRIPTION

ZZOldArchiveEntry.mm 's function (line 345):
```Objective-C
- (NSData*)newDataWithPassword:(NSString*)password error:(out NSError**)error
```
has following code (line 386-391): 
```Objective-C
if (stream.streamError)
{
	if (error)
		*error = stream.streamError;
	return nil;
}
```
When unzipping a file with aes encryption the ZZAESDecryptInputStream get used, but this stream does not have _error or streamError.
Added missing streamError like in ZZStandardDecryptInputStream.mm, which also does not have _error and returns nil (line 67-70):
```Objective-C
- (NSError*)streamError
{
	return nil;
}
```