### PR TITLE
Fix a Crash when trying to extract an encrypted zip with nil password

### DIFF
--- a/ZipZap/ZZStandardCryptoEngine.h
+++ b/ZipZap/ZZStandardCryptoEngine.h
@@ -18,10 +18,12 @@ public:
 		keys[0] = 305419896;
 		keys[1] = 591751049;
 		keys[2] = 878082192;
-		while (*password)
-		{
-			updateKeys((*password) & 0xff);
-			password++;
+		if (password) {
+			while (*password)
+			{
+				updateKeys((*password) & 0xff);
+				password++;
+			}
 		}
 	}
 

--- a/ZipZapTests/ZZDecryptTests.m
+++ b/ZipZapTests/ZZDecryptTests.m
@@ -24,6 +24,18 @@
 	XCTAssertEqual(error.code, ZZWrongPassword, @"[fileEntry newDataWithPassword:...] should set error to ZZWrongPassword");
 }
 
+- (void)testExtractingAndStandardDecryptingNilPassword
+{ // This file was small to begin with, encrypted with Standard and Store compression mode
+	ZZArchive* zipFile = [ZZArchive archiveWithURL:[[NSBundle bundleForClass:self.class] URLForResource:@"small-test-encrypted-standard" withExtension:@"zip"]
+											 error:nil];
+	
+	ZZArchiveEntry *fileEntry = zipFile.entries[0];
+	NSError* error = nil;
+	
+	XCTAssertNil([fileEntry newDataWithPassword:nil error:&error], @"[fileEntry newDataWithPassword:...] should be nil with wrong password");
+	XCTAssertEqual(error.code, ZZWrongPassword, @"[fileEntry newDataWithPassword:...] should set error to ZZWrongPassword");
+}
+
 - (void)testExtractingAndStandardDecryptingSmallZipEntryData
 { // This file was small to begin with, encrypted with Standard and Store compression mode
 	ZZArchive* zipFile = [ZZArchive archiveWithURL:[[NSBundle bundleForClass:self.class] URLForResource:@"small-test-encrypted-standard" withExtension:@"zip"]


### PR DESCRIPTION
Since the method "newDataWithError:" is calling "newDataWithPassword:error:" with password set to nil, NewDataWithPassword should not throw an error when password is nil.

I ran into this issue while debugging a crash in my application.