### PR TITLE
Adds Carthage/Build into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 xcuserdata
 project.xcworkspace
+Carthage/Build


### PR DESCRIPTION
This is so that ZipZap plays nicer when used with carthage (esp with the flag `--use-submodules` enabled)