### PR TITLE
Add watchOS to available platforms

### DIFF
--- a/zipzap.podspec.json
+++ b/zipzap.podspec.json
@@ -15,7 +15,8 @@
   "documentation_url": "http://pixelglow.github.io/ZipZap/api/",
   "platforms": {
     "ios": "7.0",
-    "osx": "10.9"
+    "osx": "10.9",
+    "watchos": "3.0"
   },
   "requires_arc": true,
   "frameworks": [


### PR DESCRIPTION
This compiles perfectly for watchOS 3, so unless there's a reason not to add this, it should work as expected!