### PR TITLE
Static analyzer warning fixes

### DIFF
--- a/ZipZap/ZZArchive.mm
+++ b/ZipZap/ZZArchive.mm
@@ -100,8 +100,6 @@ static const size_t ENDOFCENTRALDIRECTORY_MINSEARCH = sizeof(ZZEndOfCentralDirec
 	{
 		if (canMiss && readError.code == NSFileReadNoSuchFileError && [readError.domain isEqualToString:NSCocoaErrorDomain])
 		{
-			_contents = nil;
-			_entries = nil;
 			return YES;
 		}
 		else

--- a/ZipZap/ZZArchiveEntry.m
+++ b/ZipZap/ZZArchiveEntry.m
@@ -92,7 +92,8 @@
 
 - (NSDate*)lastModified
 {
-	return nil;
+	// This is an abstract class. This method cannot be called and should instead be implemented by a subclass.
+	return (id _Nonnull)nil;
 }
 
 - (NSUInteger)crc32
@@ -122,7 +123,8 @@
 
 - (NSData*)rawFileName
 {
-	return nil;
+	// This is an abstract class. This method cannot be called and should instead be implemented by a subclass.
+	return (id _Nonnull)nil;
 }
 
 - (NSStringEncoding)encoding
@@ -147,7 +149,8 @@
 
 - (NSString*)fileNameWithEncoding:(NSStringEncoding)encoding
 {
-	return nil;
+	// This is an abstract class. This method cannot be called and should instead be implemented by a subclass.
+	return (id _Nonnull)nil;
 }
 
 - (NSData*)newDataWithError:(NSError**)error
@@ -172,7 +175,8 @@
 
 - (id<ZZArchiveEntryWriter>)newWriterCanSkipLocalFile:(BOOL)canSkipLocalFile
 {
-	return nil;
+	// This is an abstract class. This method cannot be called and should instead be implemented by a subclass.
+	return (id _Nonnull)nil;
 }
 
 @end

--- a/ZipZap/ZZInflateInputStream.h
+++ b/ZipZap/ZZInflateInputStream.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ZZInflateInputStream : NSInputStream
 
-+ (NSData*)decompressData:(NSData*)data
++ (nullable NSData*)decompressData:(NSData*)data
 	 withUncompressedSize:(NSUInteger)uncompressedSize;
 
 - (instancetype)initWithStream:(NSInputStream*)upstream;


### PR DESCRIPTION
This gets rid of the static analyzer warning fixes mentioned on [Issue #150](https://github.com/pixelglow/ZipZap/issues/150).
