### PR TITLE
Japanese file name garbled

### DIFF
--- a/ZipZap/ZZOldArchiveEntry.mm
+++ b/ZipZap/ZZOldArchiveEntry.mm
@@ -250,9 +250,19 @@
 
 - (NSString*)fileNameWithEncoding:(NSStringEncoding)encoding
 {
-	return [[NSString alloc] initWithBytes:_centralFileHeader->fileName()
+	
+	NSString *encodedString = nil;
+	
+	if (encoding == CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingDOSLatinUS)) {
+		BOOL lossyConversion = NO;
+		NSData *data = [NSData dataWithBytesNoCopy:_centralFileHeader->fileName() length:_centralFileHeader->fileNameLength freeWhenDone:NO];
+		[NSString stringEncodingForData:data encodingOptions:nil convertedString:&encodedString usedLossyConversion:&lossyConversion];
+	} else {
+	  encodedString = [[NSString alloc] initWithBytes:_centralFileHeader->fileName()
 									length:_centralFileHeader->fileNameLength
 								  encoding:encoding];
+	}
+	return encodedString;
 }
 
 - (BOOL)checkEncryptionAndCompression:(out NSError**)error


### PR DESCRIPTION
If ZZGeneralPurposeBitFlag is none then ZipZap is using kCFStringEncodingDOSLatinUS encoding by default

But if file name has Japanese characters then this encoding will not work and name looks garbled.

To fix this I’m using the below API
+ (NSStringEncoding)stringEncodingForData:(NSData *)data
                          encodingOptions:(nullable NSDictionary<NSStringEncodingDetectionOptionsKey, id> *)opts
                          convertedString:(NSString * _Nullable * _Nullable)string
                      usedLossyConversion:(nullable BOOL *)usedLossyConversion

This API detects the string encoding of a given raw data and It converts the data to a string in the detected string encoding.